### PR TITLE
I meet a runtime error..

### DIFF
--- a/src/torchcrf/__init__.py
+++ b/src/torchcrf/__init__.py
@@ -184,7 +184,7 @@ class CRF(nn.Module):
         for i in range(seq_length - 1):
             cur_tag, next_tag = tags[i], tags[i+1]
             # Emission score for current tag
-            llh += emissions[i].gather(1, cur_tag.view(-1, 1)).squeeze(1) * mask[i]
+            llh += emissions[i].gather(1, cur_tag.contiguous().view(-1, 1)).squeeze(1) * mask[i]
             # Transition score to next tag
             transition_score = self.transitions[cur_tag, next_tag]
             # Only add transition score if the next tag is not masked (mask == 1)


### PR DESCRIPTION
  File "/Applications/bin/anaconda3/lib/python3.6/site-packages/torchcrf/__init__.py", line 113, in forward
    numerator = self._compute_joint_llh(emissions, tags, mask)
  File "/Applications/bin/anaconda3/lib/python3.6/site-packages/torchcrf/__init__.py", line 187, in _compute_joint_llh
    llh += emissions[i].gather(1, cur_tag.view(-1, 1)).squeeze(1) * mask[i]
RuntimeError: invalid argument 1: input is not contiguous at /Users/soumith/code/builder/wheel/pytorch-src/torch/lib/TH/generic/THTensor.c:231


and I fix the bug under the suggestion by @apaszke , more details see link: https://discuss.pytorch.org/t/runtimeerror-input-is-not-contiguous/930