### PR TITLE
Allow parameters to be manually set

### DIFF
--- a/src/torchcrf/__init__.py
+++ b/src/torchcrf/__init__.py
@@ -47,17 +47,29 @@ class CRF(nn.Module):
         self.end_transitions = nn.Parameter(torch.Tensor(num_tags))
         self.transitions = nn.Parameter(torch.Tensor(num_tags, num_tags))
 
-        self.reset_parameters()
+        self.initialize_parameters()
 
-    def reset_parameters(self) -> None:
+    def initialize_parameters(self,
+                              start_transitions=None,
+                              end_transitions=None,
+                              transitions=None) -> None:
         """Initialize the transition parameters.
 
         The parameters will be initialized randomly from a uniform distribution
-        between -0.1 and 0.1.
+        between -0.1 and 0.1, unless given explicitly as an argument.
         """
-        nn.init.uniform(self.start_transitions, -0.1, 0.1)
-        nn.init.uniform(self.end_transitions, -0.1, 0.1)
-        nn.init.uniform(self.transitions, -0.1, 0.1)
+        if start_transitions is None:
+            nn.init.uniform(self.start_transitions, -0.1, 0.1)
+        else:
+            self.start_transitions.data = start_transitions
+        if end_transitions is None:
+            nn.init.uniform(self.end_transitions, -0.1, 0.1)
+        else:
+            self.end_transitions.data = end_transitions
+        if transitions is None:
+            nn.init.uniform(self.transitions, -0.1, 0.1)
+        else:
+            self.transitions.data = transitions
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(num_tags={self.num_tags})'

--- a/src/torchcrf/__init__.py
+++ b/src/torchcrf/__init__.py
@@ -47,7 +47,7 @@ class CRF(nn.Module):
         self.end_transitions = nn.Parameter(torch.Tensor(num_tags))
         self.transitions = nn.Parameter(torch.Tensor(num_tags, num_tags))
 
-        self.initialize_parameters()
+        self.reset_parameters()
 
     def initialize_parameters(self,
                               start_transitions=None,
@@ -70,6 +70,9 @@ class CRF(nn.Module):
             nn.init.uniform(self.transitions, -0.1, 0.1)
         else:
             self.transitions.data = transitions
+
+    def reset_parameters(self):
+        self.initialize_parameters()
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(num_tags={self.num_tags})'

--- a/tests/test_crf.py
+++ b/tests/test_crf.py
@@ -205,6 +205,19 @@ class TestForward(object):
             excinfo.value
         )
 
+    def test_intialize_parameters(self):
+        emissions = torch.autograd.Variable(torch.randn(2, 2, 3), requires_grad=True)
+        tags = torch.autograd.Variable(torch.LongTensor([[2, 1], [2, 1]]))
+        mask = torch.autograd.Variable(torch.ByteTensor([[1, 1], [1, 0]]))
+        crf = CRF(3)
+        llh = float(crf(emissions, tags, mask))
+        crf_other = CRF(3)
+        crf_other.initialize_parameters(crf.start_transitions.data,
+                                        crf.end_transitions.data,
+                                        crf.transitions.data)
+        llh_other = float(crf_other(emissions, tags, mask))
+        assert llh == llh_other
+
     def test_first_timestep_mask_is_not_all_on(self):
         emissions = torch.autograd.Variable(torch.randn(1, 2, 3), requires_grad=True)
         tags = torch.autograd.Variable(torch.LongTensor(1, 2))


### PR DESCRIPTION
This change allows the user to manually specify the parameters of the CRF. For instance, this means the user can apply masking (say disallowed transitions) to the parameters.

This PR is also helpful for testing (we can now specify the internal state of the CRF).

Tests and linters pass.