### PR TITLE
PyTorch 0.4.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: python
-env:
-  - PYTORCH_VERSION=0.3.0
-  - PYTORCH_VERSION=0.3.1
 before_install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
   - bash ~/miniconda.sh -b -p $HOME/miniconda
@@ -9,9 +6,7 @@ before_install:
   - conda update -y conda
   - conda create -y -n pytorch-crf python=3.6
   - source activate pytorch-crf
-  - conda install -y -c pytorch pytorch=$PYTORCH_VERSION
-  # explicitly specify cudatoolkit version (see https://discuss.pytorch.org/t/libcudart-so-8-0-not-found-in-travis-ci/16071/3)
-  - if [[ $PYTORCH_VERSION == "0.3.0" ]]; then conda install -y -c pytorch cudatoolkit=8.0; fi
+  - conda install -y -c pytorch pytorch=0.4.1
   - export LD_LIBRARY_PATH="$HOME/miniconda/envs/pytorch-crf/lib:$LD_LIBRARY_PATH"
 install:
   - pip install --ignore-installed -r requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ In the examples below, we will assume that these lines have been executed
     >>> import torch
     >>> from torchcrf import CRF
     >>> seq_length, batch_size, num_tags = 3, 2, 5
-    >>> emissions = torch.randn(seq_length, batch_size, num_tags, requires_grad=True)
+    >>> emissions = torch.randn(seq_length, batch_size, num_tags)
     >>> tags = torch.tensor([[0, 1], [2, 4], [3, 1]], dtype=torch.long)  # (seq_length, batch_size)
     >>> model = CRF(num_tags)
 

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Requirements
 ============
 
 - Python 3.6
-- PyTorch 0.3.0
+- PyTorch 0.4.1
 
 Installation
 ============
@@ -47,8 +47,8 @@ In the examples below, we will assume that these lines have been executed
     >>> import torch
     >>> from torchcrf import CRF
     >>> seq_length, batch_size, num_tags = 3, 2, 5
-    >>> emissions = torch.autograd.Variable(torch.randn(seq_length, batch_size, num_tags), requires_grad=True)
-    >>> tags = torch.autograd.Variable(torch.LongTensor([[0, 1], [2, 4], [3, 1]]))  # (seq_length, batch_size)
+    >>> emissions = torch.randn(seq_length, batch_size, num_tags, requires_grad=True)
+    >>> tags = torch.tensor([[0, 1], [2, 4], [3, 1]], dtype=torch.long)  # (seq_length, batch_size)
     >>> model = CRF(num_tags)
 
 Computing log likelihood
@@ -57,20 +57,16 @@ Computing log likelihood
 .. code-block:: python
 
     >>> model(emissions, tags)
-    Variable containing:
-    -10.0635
-    [torch.FloatTensor of size 1]
+    tensor(-12.7431, grad_fn=<SumBackward0>)
 
 Computing log likelihood with mask
 ----------------------------------
 
 .. code-block:: python
 
-    >>> mask = torch.autograd.Variable(torch.ByteTensor([[1, 1], [1, 1], [1, 0]]))  # (seq_length, batch_size)
+    >>> mask = torch.tensor([[1, 1], [1, 1], [1, 0]], dtype=torch.uint8)  # (seq_length, batch_size)
     >>> model(emissions, tags, mask=mask)
-    Variable containing:
-    -8.4981
-    [torch.FloatTensor of size 1]
+    tensor(-10.8390, grad_fn=<SumBackward0>)
 
 Decoding
 --------

--- a/src/torchcrf/__init__.py
+++ b/src/torchcrf/__init__.py
@@ -43,9 +43,9 @@ class CRF(nn.Module):
             raise ValueError(f'invalid number of tags: {num_tags}')
         super().__init__()
         self.num_tags = num_tags
-        self.start_transitions = nn.Parameter(torch.Tensor(num_tags))
-        self.end_transitions = nn.Parameter(torch.Tensor(num_tags))
-        self.transitions = nn.Parameter(torch.Tensor(num_tags, num_tags))
+        self.start_transitions = nn.Parameter(torch.empty(num_tags))
+        self.end_transitions = nn.Parameter(torch.empty(num_tags))
+        self.transitions = nn.Parameter(torch.empty(num_tags, num_tags))
 
         self.reset_parameters()
 

--- a/src/torchcrf/__init__.py
+++ b/src/torchcrf/__init__.py
@@ -55,9 +55,9 @@ class CRF(nn.Module):
         The parameters will be initialized randomly from a uniform distribution
         between -0.1 and 0.1.
         """
-        nn.init.uniform(self.start_transitions, -0.1, 0.1)
-        nn.init.uniform(self.end_transitions, -0.1, 0.1)
-        nn.init.uniform(self.transitions, -0.1, 0.1)
+        nn.init.uniform_(self.start_transitions, -0.1, 0.1)
+        nn.init.uniform_(self.end_transitions, -0.1, 0.1)
+        nn.init.uniform_(self.transitions, -0.1, 0.1)
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(num_tags={self.num_tags})'
@@ -278,7 +278,7 @@ class CRF(nn.Module):
             # for the last timestep
             seq_end = sequence_lengths[idx]-1
             _, best_last_tag = (viterbi_score[seq_end][idx] + self.end_transitions).max(0)
-            best_tags = [best_last_tag[0]]
+            best_tags = [best_last_tag.item()]
 
             # We trace back where the best last tag comes from, append that to our best tag
             # sequence, and trace it back again, and so on

--- a/src/torchcrf/__init__.py
+++ b/src/torchcrf/__init__.py
@@ -111,7 +111,7 @@ class CRF(nn.Module):
                 raise ValueError('mask of the first timestep must all be on')
 
         if mask is None:
-            mask = Variable(self._new(tags.size()).fill_(1)).byte()
+            mask = torch.ones_like(tags, dtype=torch.uint8)
 
         numerator = self._compute_joint_llh(emissions, tags, mask)
         denominator = self._compute_log_partition_function(emissions, mask)
@@ -149,7 +149,7 @@ class CRF(nn.Module):
             )
 
         if mask is None:
-            mask = self._new(emissions.size()[:2]).fill_(1).byte()
+            mask = emissions.new_ones(emissions.shape[:2], dtype=torch.uint8)
 
         return self._viterbi_decode(emissions, mask)
 
@@ -301,7 +301,3 @@ class CRF(nn.Module):
         safe_log_sum_exp = torch.log(torch.sum(torch.exp(tensor - broadcast_offset), dim))
         # Add offset back
         return offset + safe_log_sum_exp
-
-    def _new(self, *args, **kwargs) -> Union[torch.FloatTensor, torch.cuda.FloatTensor]:
-        param = next(self.parameters())
-        return param.new(*args, **kwargs)

--- a/src/torchcrf/__init__.py
+++ b/src/torchcrf/__init__.py
@@ -273,7 +273,7 @@ class CRF(nn.Module):
         for idx in range(batch_size):
             # Find the tag which maximizes the score at the last timestep; this is our best tag
             # for the last timestep
-            seq_end = sequence_lengths[idx]-1
+            seq_end = sequence_lengths[idx] - 1
             _, best_last_tag = (viterbi_score[seq_end][idx] + self.end_transitions).max(0)
             best_tags = [best_last_tag.item()]
 
@@ -281,7 +281,7 @@ class CRF(nn.Module):
             # sequence, and trace it back again, and so on
             for path in reversed(viterbi_path[:sequence_lengths[idx] - 1]):
                 best_last_tag = path[idx][best_tags[-1]]
-                best_tags.append(best_last_tag)
+                best_tags.append(best_last_tag.item())
 
             # Reverse the order because we start from the last timestep
             best_tags.reverse()

--- a/tests/test_crf.py
+++ b/tests/test_crf.py
@@ -298,7 +298,7 @@ class TestDecode(object):
         batch_size, seq_len, num_tags = 2, 3, 4
         crf = CRF(num_tags)
         emissions = torch.randn(seq_len, batch_size, num_tags)
-        mask = torch.ByteTensor([[1, 1, 1], [1, 1, 0]]).transpose(0, 1)
+        mask = torch.tensor([[1, 1, 1], [1, 1, 0]], dtype=torch.uint8).transpose(0, 1)
 
         # non-batched
         non_batched = []

--- a/tests/test_crf.py
+++ b/tests/test_crf.py
@@ -239,6 +239,7 @@ class TestDecode(object):
         emissions = emissions.transpose(0, 1)
         # Compute best tag manually
         for emission, best_tag in zip(emissions, best_tags):
+            assert all(isinstance(t, int) for t in best_tag)
             manual_best_tag = max(itertools.product(range(crf.num_tags), repeat=seq_length),
                                   key=lambda t: compute_score(crf, emission, t))
             assert tuple(best_tag) == manual_best_tag
@@ -263,6 +264,7 @@ class TestDecode(object):
         for emission, best_tag, mask_ in zip(emissions, best_tags, mask):
             seq_len = mask_.sum()
             assert len(best_tag) == seq_len
+            assert all(isinstance(t, int) for t in best_tag)
             emission = emission[:seq_len]
             manual_best_tag = max(itertools.product(range(crf.num_tags), repeat=seq_len),
                                   key=lambda t: compute_score(crf, emission, t))

--- a/tests/test_crf.py
+++ b/tests/test_crf.py
@@ -76,14 +76,14 @@ class TestForward(object):
         llh = crf(emissions, tags)
 
         assert isinstance(llh, torch.autograd.Variable)
-        assert llh.size() == (1,)
+        assert llh.size() == ()
         total_llh = 0.
         for i in range(batch_size):
             emissions_ = emissions[:, i, :].unsqueeze(1)
             tags_ = tags[:, i].unsqueeze(1)
             total_llh += crf(emissions_, tags_)
 
-        assert llh.data[0] == approx(total_llh.data[0])
+        assert llh.item() == approx(total_llh.item())
 
     def test_works_with_mask(self):
         crf = make_crf()
@@ -114,7 +114,7 @@ class TestForward(object):
             denominator = math.log(sum(math.exp(s) for s in all_scores))
             manual_llh += numerator - denominator
         # Assert equal to manual log likelihood
-        assert llh.data[0] == approx(manual_llh)
+        assert llh.item() == approx(manual_llh)
         # Make sure gradients can be computed
         llh.backward()
 
@@ -129,7 +129,7 @@ class TestForward(object):
         mask = torch.autograd.Variable(torch.ones(seq_length, batch_size)).byte()
         llh_mask = crf(emissions, tags, mask=mask)
 
-        assert llh_no_mask.data[0] == approx(llh_mask.data[0])
+        assert llh_no_mask.item() == approx(llh_mask.item())
 
     def test_not_summed_over_batch(self):
         crf = make_crf()
@@ -154,7 +154,7 @@ class TestForward(object):
             manual_llh.append(numerator - denominator)
 
         for llh_, manual_llh_ in zip(llh.data, manual_llh):
-            assert llh_ == approx(manual_llh_)
+            assert llh_.item() == approx(manual_llh_)
 
     def test_emissions_has_bad_number_of_dimension(self):
         emissions = torch.autograd.Variable(torch.randn(1, 2), requires_grad=True)


### PR DESCRIPTION
Address #15. This PR utilizes `torch.logsumexp` which is first introduced in PyTorch 0.4.1. Thus, older 0.4.x versions are not supported.