### PR TITLE
Consistent usage of pathlib

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,10 +14,9 @@
 
 from pathlib import Path
 import sys
+import re
 sys.path.insert(0, Path('..').resolve())
 
-from pathlib import Path
-import re
 
 here = Path(__file__).resolve().parent
 __version__ = re.search(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,11 +10,11 @@
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
+# documentation root, use Path.resolve to make it absolute, like shown here.
 
-import os
+from pathlib import Path
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, Path('..').resolve())
 
 from pathlib import Path
 import re

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
-import os
+from pathlib import Path
 import re
 from setuptools import setup, find_packages
 
-here = os.path.dirname(os.path.realpath(__file__))
-with open(os.path.join(here, 'README.rst')) as f:
+here = Path(__file__).resolve().parent
+with (here / 'README.rst').open() as f:
     readme = f.read()
-with open(os.path.join(here, 'torchcrf', '__init__.py')) as f:
+with (here / 'torchcrf' /  '__init__.py').open() as f:
     version = re.search(r'__version__ = (["\'])([^"\']*)\1', f.read())[2]
 
 setup(


### PR DESCRIPTION
I'm beta testing a [tool](https://github.com/sbrugman/pathlad) for automatically converting `os.path` to `pathlib.Path` calls. This repository uses both, making it a good candidate to choose one consistently.

For background, one could read these blog posts by Trey Hunner:  [Why you should be using Pathlib](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/) and [No really, pathlib is great](https://treyhunner.com/2019/01/no-really-pathlib-is-great/).