### PR TITLE
Feature: return scores from decoding phase

### DIFF
--- a/torchcrf/__init__.py
+++ b/torchcrf/__init__.py
@@ -349,7 +349,7 @@ class CRF(nn.Module):
         if self.score_reduction == 'skip':
             return best_tags_list
         else:
-            if score != 'none':
+            if self.score_reduction != 'none':
                 score = score.max(dim=1)[0]
                 score = {'sum': score.sum(),
                          'max': score.max(),


### PR DESCRIPTION
Returning the scores as a measure of how well the algorithm works on a validation set (or even training) it would be nice to get the score generated from the Viterbi algorithm and plot.  I have added a parameter (`score_reduction`), documented it and tested it.  I have tried to follow your documentation and coding to make it consistent with your package.

Thank you for writing this package.  It's well written and up to date with the latest PEP conventions.