### PR TITLE
Make compatible with torchscript

### DIFF
--- a/tests/test_crf.py
+++ b/tests/test_crf.py
@@ -300,8 +300,7 @@ class TestForward:
         with pytest.raises(ValueError) as excinfo:
             crf(emissions, tags)
         assert (
-            'the first two dimensions of emissions and tags must match, '
-            'got (1, 2) and (2, 2)') in str(excinfo.value)
+            'the first dimension of emissions and tags must match, got 1 and 2') in str(excinfo.value)
 
     def test_emissions_last_dimension_not_equal_to_number_of_tags(self):
         emissions = torch.randn(1, 2, 3)
@@ -448,8 +447,7 @@ class TestDecode:
         with pytest.raises(ValueError) as excinfo:
             crf.decode(emissions, mask=mask)
         assert (
-            'the first two dimensions of emissions and mask must match, '
-            'got (1, 2) and (2, 2)') in str(excinfo.value)
+            'number of time steps is different in emissions and mask, got 1 and 2') in str(excinfo.value)
 
     def test_first_timestep_mask_is_not_all_on(self):
         emissions = torch.randn(3, 2, 4)
@@ -467,3 +465,9 @@ class TestDecode:
         with pytest.raises(ValueError) as excinfo:
             crf.decode(emissions, mask=mask)
         assert 'mask of the first timestep must all be on' in str(excinfo.value)
+
+class TestTorchScript:
+    def test_torch_scriptable(self):
+        crf = make_crf()
+        scripted_module = torch.jit.script(crf)
+        assert hasattr(scripted_module, 'decode')

--- a/torchcrf/__init__.py
+++ b/torchcrf/__init__.py
@@ -114,7 +114,9 @@ class CRF(nn.Module):
         assert reduction == 'token_mean'
         return llh.sum() / mask.type_as(emissions).sum()
 
-    def decode(self, emissions: torch.Tensor,
+    @torch.jit.export
+    def decode(self,
+               emissions: torch.Tensor,
                mask: Optional[torch.ByteTensor] = None) -> List[List[int]]:
         """Find the most likely tag sequence using Viterbi algorithm.
 
@@ -151,16 +153,24 @@ class CRF(nn.Module):
                 f'got {emissions.size(2)}')
 
         if tags is not None:
-            if emissions.shape[:2] != tags.shape:
+            if emissions.shape[0] != tags.shape[0]:
                 raise ValueError(
-                    'the first two dimensions of emissions and tags must match, '
-                    f'got {tuple(emissions.shape[:2])} and {tuple(tags.shape)}')
+                    'the first dimension of emissions and tags must match, '
+                    f'got {emissions.shape[0]} and {tags.shape[0]}')
+            if emissions.shape[1] != tags.shape[1]:
+                raise ValueError(
+                    'the second dimension of emissions and tags must match, '
+                    f'got {emissions.shape[1]} and {tags.shape[1]}')
 
         if mask is not None:
-            if emissions.shape[:2] != mask.shape:
+            if emissions.shape[0] != mask.shape[0]:
                 raise ValueError(
-                    'the first two dimensions of emissions and mask must match, '
-                    f'got {tuple(emissions.shape[:2])} and {tuple(mask.shape)}')
+                    f'number of time steps is different in emissions and mask, '
+                    f'got {emissions.shape[0]} and {mask.shape[0]}')
+            if emissions.shape[1] != mask.shape[1]:
+                raise ValueError(
+                    f'number of sequences is different in emissions and mask, '
+                    f'got {emissions.shape[1]} and {mask.shape[1]}')
             no_empty_seq = not self.batch_first and mask[0].all()
             no_empty_seq_bf = self.batch_first and mask[:, 0].all()
             if not no_empty_seq and not no_empty_seq_bf:
@@ -270,7 +280,7 @@ class CRF(nn.Module):
         # Start transition and first emission
         # shape: (batch_size, num_tags)
         score = self.start_transitions + emissions[0]
-        history = []
+        history: List[torch.Tensor] = []
 
         # score is a tensor of size (batch_size, num_tags) where for every batch,
         # value at column j stores the score of the best tag sequence so far that ends
@@ -313,17 +323,17 @@ class CRF(nn.Module):
 
         # shape: (batch_size,)
         seq_ends = mask.long().sum(dim=0) - 1
-        best_tags_list = []
+        best_tags_list: List[List[int]] = []
 
         for idx in range(batch_size):
             # Find the tag which maximizes the score at the last timestep; this is our best tag
             # for the last timestep
             _, best_last_tag = score[idx].max(dim=0)
-            best_tags = [best_last_tag.item()]
+            best_tags: List[int] = [int(best_last_tag.item())]
 
             # We trace back where the best last tag comes from, append that to our best tag
             # sequence, and trace it back again, and so on
-            for hist in reversed(history[:seq_ends[idx]]):
+            for hist in history[:seq_ends[idx]][::-1]:
                 best_last_tag = hist[idx][best_tags[-1]]
                 best_tags.append(best_last_tag.item())
 


### PR DESCRIPTION
Hey there!

Many people want this repository to be compatible with TorchScript #100 #79 to be available for mobile inference.
We found a simple and non-breaking solution and hope that it can be merged.

We added a test that scripts the CRF module. 
Because the scripted module should also include the decode method we added the `@torch.jit.export` annotation.

We had to make two other changes to make it work:

- `emissions.shape[:2] != tags.shape` is not scriptable and throws the error `cannot statically infer the expected size of a list in this context`. We changed it so that the two dimensions are checked individually.

```
E       RuntimeError: 
E       cannot statically infer the expected size of a list in this context:
E         File "/home/erik/Projects/voize/pytorch-crf/torchcrf/__init__.py", line 156
E                   if emissions.shape[:2] != tags.shape:
E                       raise ValueError(
E                           'the first two dimensions of emissions and tags must match, '
E                            ~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
E                           f'got {tuple(emissions.shape[:2])} and {tuple(tags.shape)}')
E           
E       'CRF._validate' is being compiled since it was called from 'CRF.forward'
E         File "/home/erik/Projects/voize/pytorch-crf/torchcrf/__init__.py", line 90
E                   reduction is ``none``, ``()`` otherwise.
E               """
E               self._validate(emissions, tags=tags, mask=mask)
E               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
E               if reduction not in ('none', 'sum', 'mean', 'token_mean'):
E                   raise ValueError(f'invalid reduction: {reduction}')
``` 
- same for `emissions.shape[:2] != mask.shape` 
- `reversed(history[:seq_ends[idx]])` in `_viterbi_decode` seemed not to be supported, we changed to `history[:seq_ends[idx]][::-1]`

``` 
E       RuntimeError: 
E       
E       reversed(Tensor 0) -> Tensor 0:
E       Expected a value of type 'Tensor' for argument '0' but instead found type 'List[Tensor]'.
E       Empty lists default to List[Tensor]. Add a variable annotation to the assignment to create an empty list of another type (torch.jit.annotate(List[T, []]) where T is the type of elements in the list for Python 2)
E       :
E         File "/home/erik/Projects/voize/pytorch-crf/torchcrf/__init__.py", line 335
E                   # We trace back where the best last tag comes from, append that to our best tag
E                   # sequence, and trace it back again, and so on
E                   for hist in reversed(history[:seq_ends[idx]]):
E                               ~~~~~~~~ <--- HERE
E                       best_last_tag = hist[idx][best_tags[-1]]
E                       best_tags.append(best_last_tag.item())
E       'CRF._viterbi_decode' is being compiled since it was called from 'CRF.decode'
E         File "/home/erik/Projects/voize/pytorch-crf/torchcrf/__init__.py", line 140
E                   mask = mask.transpose(0, 1)
E           
E               return self._viterbi_decode(emissions, mask)
E                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
```
- `best_last_tag.item()` needs to be casted to an int, otherwise the inferred type can not be used to index `hist[idx]`

```
E       RuntimeError: 
E       Unsupported operation: indexing tensor with unsupported index type 'number'. Only ints, slices, lists and tensors are supported:
E         File "/home/erik/Projects/voize/pytorch-crf/torchcrf/__init__.py", line 337
E                   # sequence, and trace it back again, and so on
E                   for hist in history[:seq_ends[idx]][::-1]:
E                       best_last_tag = hist[idx][best_tags[-1]]
E                                       ~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
E                       best_tags.append(best_last_tag.item())
E           
E       'CRF._viterbi_decode' is being compiled since it was called from 'CRF.decode'
E         File "/home/erik/Projects/voize/pytorch-crf/torchcrf/__init__.py", line 141
E                   mask = mask.transpose(0, 1)
E           
E               return self._viterbi_decode(emissions, mask)
E                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
```