### PR TITLE
Update CI python

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7"]
-        pytorch-version: ["1.2"]
+        python-version: ["3.8"]
+        pytorch-version: ["1.4", "2.0"]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@
 torch
 pytest>=8,<9
 pytest-cov>=2,<3
+packaging

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,5 +2,5 @@
 # compatible with yours. If so, install PyTorch with the correct CUDA version
 # as instructed on https://pytorch.org/get-started/locally/
 torch
-pytest==3.2.5
-pytest-cov==2.5.1
+pytest>=8,<9
+pytest-cov>=2,<3


### PR DESCRIPTION
Update the python version in CI to fix CI failure. Fixes the test breakage due to package updates.

Fixes https://github.com/kmkurn/pytorch-crf/issues/117.